### PR TITLE
Support of figcaption in all RSCE templates that output images.

### DIFF
--- a/src/Resources/contao/templates/rsce/rsce_image_list.html5
+++ b/src/Resources/contao/templates/rsce/rsce_image_list.html5
@@ -15,6 +15,10 @@
                  <figure class="image_container">
                      <?php if ($image = $this->getImageObject($item->singleSRC, $this->size)): ?>
                          <?php $this->insert('picture_default', $image->picture) ?>
+
+                         <?php if($image->caption): ?>
+                             <figcaption><?php echo $image->caption ?></figcaption>
+                         <?php endif; ?>
                      <?php endif ?>
                  </figure>
              </div>

--- a/src/Resources/contao/templates/rsce/rsce_image_text.html5
+++ b/src/Resources/contao/templates/rsce/rsce_image_text.html5
@@ -25,6 +25,10 @@
         <figure class="image_container">
             <?php if ($image = $this->getImageObject($this->singleSRC, $this->size)): ?>
                 <?php $this->insert('picture_default', $image->picture) ?>
+
+                <?php if($image->caption): ?>
+                    <figcaption><?php echo $image->caption ?></figcaption>
+                <?php endif; ?>
             <?php endif ?>
         </figure>
     </div>

--- a/src/Resources/contao/templates/rsce/rsce_image_text_list.html5
+++ b/src/Resources/contao/templates/rsce/rsce_image_text_list.html5
@@ -15,6 +15,10 @@
                  <figure class="image_container">
                      <?php if ($image = $this->getImageObject($item->singleSRC, $this->size)): ?>
                          <?php $this->insert('picture_default', $image->picture) ?>
+
+                         <?php if($image->caption): ?>
+                             <figcaption><?php echo $image->caption ?></figcaption>
+                         <?php endif; ?>
                      <?php endif ?>
                  </figure>
              </div>


### PR DESCRIPTION
Currently, the ThemeManager elements do not support figcaptions in the templates. I have now added these within the Figures. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption 