### PR TITLE
Force button to full width

### DIFF
--- a/src/Resources/public/framework/scss/styles/_button.scss
+++ b/src/Resources/public/framework/scss/styles/_button.scss
@@ -1,7 +1,7 @@
 button, a, input[type="submit"] {
   // Allow is-block even if no button class is selected
   &.is-block {
-    display: block;
+    display: block !important;
   }
 }
 


### PR DESCRIPTION
button full-width does not work anymore because the button is display-inline and has more strength in the hierarchy. The important sets it above this value.