### PR TITLE
Form-rework

### DIFF
--- a/contao/templates/forms/form_captcha.html5
+++ b/contao/templates/forms/form_captcha.html5
@@ -1,4 +1,4 @@
-<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?> pfield">
+<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
   <?php if ($this->label): ?>
     <label for="ctrl_<?= $this->id ?>"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>

--- a/contao/templates/forms/form_checkbox.html5
+++ b/contao/templates/forms/form_checkbox.html5
@@ -2,7 +2,7 @@
 
 <div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
-  <div role="group" aria-label="legend" id="ctrl_<?= $this->id ?>" class="checkbox_container grid-list gtr-f<?= $sm ? $sm->prepare('eGridList')->format(' %s') : '' ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
+  <div role="group" aria-label="legend" id="ctrl_<?= $this->id ?>" class="checkbox_container crc grid-list gtr-f<?= $sm ? $sm->prepare('eGridList')->format(' %s') : '' ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
     <?php if ($this->label): ?>
       <legend>
@@ -24,7 +24,7 @@
 
       <?php if ('option' == $option['type']): ?>
         <div>
-          <input type="checkbox" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="checkbox" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
+          <input type="checkbox" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="checkbox crt" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
           <label class="lbl-tgl" id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
         </div>
       <?php endif; ?>

--- a/contao/templates/forms/form_checkbox.html5
+++ b/contao/templates/forms/form_checkbox.html5
@@ -25,7 +25,7 @@
       <?php if ('option' == $option['type']): ?>
         <div>
           <input type="checkbox" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="checkbox" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
-          <label id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
+          <label class="lbl-tgl" id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
         </div>
       <?php endif; ?>
 

--- a/contao/templates/forms/form_radio.html5
+++ b/contao/templates/forms/form_radio.html5
@@ -23,7 +23,7 @@
       <?php if ('option' == $option['type']): ?>
         <div>
           <input type="radio" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="radio" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
-          <label id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
+          <label class="lbl-tgl lbr-50" id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
         </div>
       <?php endif; ?>
 

--- a/contao/templates/forms/form_radio.html5
+++ b/contao/templates/forms/form_radio.html5
@@ -2,7 +2,7 @@
 
 <div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
-  <div role="radiogroup" aria-label="legend" id="ctrl_<?= $this->id ?>" class="radio_container grid-list gtr-f<?= $sm ? $sm->prepare('eGridList')->format(' %s') : '' ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
+  <div role="radiogroup" aria-label="legend" id="ctrl_<?= $this->id ?>" class="radio_container crc grid-list gtr-f<?= $sm ? $sm->prepare('eGridList')->format(' %s') : '' ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
     <?php if ($this->label): ?>
       <legend>
@@ -22,7 +22,7 @@
 
       <?php if ('option' == $option['type']): ?>
         <div>
-          <input type="radio" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="radio" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
+          <input type="radio" name="<?= $option['name'] ?>" id="opt_<?= $option['id'] ?>" class="radio crt" value="<?= $option['value'] ?>"<?= $option['checked'] ?><?= $option['attributes'] ?>>
           <label class="lbl-tgl lbr-50" id="lbl_<?= $option['id'] ?>" for="opt_<?= $option['id'] ?>"><?= $option['label'] ?></label>
         </div>
       <?php endif; ?>

--- a/contao/templates/forms/form_row.html5
+++ b/contao/templates/forms/form_row.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?> pfield">
+<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
   <?php $this->block('label'); ?>
   <?php $this->endblock(); ?>
 

--- a/contao/templates/forms/form_select.html5
+++ b/contao/templates/forms/form_select.html5
@@ -1,4 +1,4 @@
-<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?> pfield">
+<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
   <?php if ($this->label): ?>
     <label for="ctrl_<?= $this->id ?>"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>

--- a/contao/templates/forms/form_textarea.html5
+++ b/contao/templates/forms/form_textarea.html5
@@ -1,4 +1,4 @@
-<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?> pfield">
+<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
   <?php if ($this->label): ?>
     <label for="ctrl_<?= $this->id ?>"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>

--- a/contao/templates/forms/form_textfield.html5
+++ b/contao/templates/forms/form_textfield.html5
@@ -1,4 +1,4 @@
-<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?> pfield">
+<div class="<?= $this->prefix ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>">
 
   <?php if ($this->label): ?>
     <label for="ctrl_<?= $this->id ?>"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?>>

--- a/contao/templates/modules/mod_login.html5
+++ b/contao/templates/modules/mod_login.html5
@@ -39,7 +39,7 @@
           <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->lastLogin ?></p>
         <?php elseif ($this->twoFactorEnabled): ?>
           <h3><?= $this->twoFactorAuthentication ?></h3>
-          <div class="widget widget-text pfield">
+          <div class="widget widget-text">
             <label for="verify"><?= $this->authCode ?></label>
             <div class="input-container">
               <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="one-time-code" required>
@@ -50,13 +50,13 @@
             <label for="trusted"><?= $this->trans('MSC.twoFactorTrustDevice') ?></label>
           </div>
         <?php else: ?>
-          <div class="widget widget-text pfield">
+          <div class="widget widget-text">
             <label for="username"><?= $this->username ?></label>
             <div class="input-container">
               <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" autocapitalize="off" autocomplete="username" required>
             </div>
           </div>
-          <div class="widget widget-password pfield">
+          <div class="widget widget-password">
             <label for="password"><?= $this->password ?></label>
             <div class="input-container">
               <input type="password" name="password" id="password" class="text password" value="" autocomplete="current-password" required>

--- a/contao/templates/modules/mod_search.html5
+++ b/contao/templates/modules/mod_search.html5
@@ -10,7 +10,7 @@
 
   <form class="grid gtr-f<?= $formClasses ?>"<?php if ($this->action): ?> action="<?= $this->action ?>"<?php endif; ?> method="get">
     <div class="formbody inside">
-      <div class="widget widget-text pfield">
+      <div class="widget widget-text">
         <label for="ctrl_keywords_<?= $this->uniqueId ?>" class="invisible"><?= $this->keywordLabel ?></label>
         <input type="search" name="keywords" id="ctrl_keywords_<?= $this->uniqueId ?>" class="text" value="<?= $this->keyword ?>">
       </div>

--- a/contao/templates/modules/mod_two_factor.html5
+++ b/contao/templates/modules/mod_two_factor.html5
@@ -39,7 +39,7 @@
             <p><?= $this->trans('MSC.twoFactorTextCode') ?></p>
             <code style="word-break:break-all"><?= $this->secret ?></code>
           </div>
-          <div class="widget widget-text pfield">
+          <div class="widget widget-text">
             <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>
             <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="one-time-code" required>
             <p class="help"><?= $this->trans('MSC.twoFactorVerificationHelp') ?></p>

--- a/public/framework/scss/_components/_form.scss
+++ b/public/framework/scss/_components/_form.scss
@@ -31,7 +31,6 @@
 
 label,
 legend {
-  //display: inline-block;
   color: var(--form-clr-label);
   font-size: $form-label-font-size;
   margin-bottom: $form-label-spacing;
@@ -135,11 +134,6 @@ textarea {
 
       font-size: $form-select-symbol-font-size;
       line-height: 1;
-      //height: 1em;
-      //width: 1em;
-
-
-      //text-align: center;
       text-decoration: inherit;
       text-transform: none;
 

--- a/public/framework/scss/_components/_form.scss
+++ b/public/framework/scss/_components/_form.scss
@@ -50,18 +50,18 @@ select {
   text-overflow: '';
   -webkit-appearance: none;
   -moz-appearance: none;
+}
 
-  option {
-    color: $form-select-option-color;
-    background-color: $form-select-option-background;
+.multiselect {
+  resize: vertical;
+  height: $form-multiselect-height;
+}
 
-    &[disabled] { color: $form-input-color-disabled; }
-  }
+option {
+  color: $form-select-option-color;
+  background-color: $form-select-option-background;
 
-  &.multiselect {
-    resize: vertical;
-    height: $form-multiselect-height;
-  }
+  &[disabled] { color: $form-input-color-disabled; }
 }
 
 select,
@@ -194,7 +194,7 @@ textarea {
     }
   }
 
-  // checkbox & -radio styles
+  /*// checkbox & -radio styles
 
   // Calculation for checkbox and radio offsets for pseudo or text element
   $form-checkbox-radio-label-offset:  0;
@@ -213,9 +213,9 @@ textarea {
       $form-checkbox-radio-symbol-offset: 0;
       $form-checkbox-radio-label-offset:  $--calc-offset;
     }
-  }
+  }*/
 
-  &-checkbox,
+  /*&-checkbox,
   &-radio {
 
     input {
@@ -314,14 +314,14 @@ textarea {
         top: 0;
       }
     }
-  }
+  }*/
 
-  &-radio {
+  /*&-radio {
 
     label:before {
       border-radius: 50%;
     }
-  }
+  }*/
 
   &-range {
 
@@ -379,5 +379,135 @@ textarea {
     &:required:invalid {
       @extend %form-error-styles;
     }
+  }
+}
+
+// checkbox & -radio styles
+
+// Calculation for checkbox and radio offsets for pseudo or text element
+$form-checkbox-radio-label-offset:  0;
+$form-checkbox-radio-symbol-offset: 1px;
+$form-checkbox-radio-label-min-height: $form-checkbox-radio-size;
+
+@if ($form-checkbox-radio-auto-align == 'Active') {
+  $font-min-height: multiply($form-checkbox-radio-label-font-size, $form-checkbox-radio-label-line-height);
+
+  @if ($form-checkbox-radio-size < $font-min-height) {
+    $form-checkbox-radio-symbol-offset: sub(divide(sub($font-min-height, $form-checkbox-radio-size), 2), 1px);
+  }
+  @else if ($form-checkbox-radio-size > $font-min-height) {
+    $--calc-offset: sum(divide(sub($form-checkbox-radio-size, $font-min-height), 2), 1px);
+
+    $form-checkbox-radio-symbol-offset: 0;
+    $form-checkbox-radio-label-offset:  $--calc-offset;
+  }
+}
+
+[type=radio],
+[type=checkbox] {
+  position: absolute;
+  opacity: 0;
+  z-index: 1;
+  width: 1px;
+
+  /*&:checked + label {
+
+    &:before {
+      border-color: $form-checkbox-radio-border-color-focus;
+      background-color: $form-checkbox-radio-background-focus;
+    }
+
+    &:after {
+      display: inline-block;
+      content: $form-checkbox-radio-symbol;
+      font-family: $form-checkbox-radio-symbol-font-family;
+
+      position: absolute;
+      left: 1px;
+      top: $form-checkbox-radio-symbol-offset;
+
+      width: sub($form-checkbox-radio-size, 1px, 'px');
+      line-height: $form-checkbox-radio-size;
+      color: var(--cbx-symbol-clr);
+
+      // Calculation: Do not allow font-sizes bigger than the width of the the checkbox
+      $checkboxInnerWidth: sub($form-checkbox-radio-size, multiply($form-checkbox-radio-border-width, 2), 'px');
+      font-size: minUnit($form-checkbox-radio-symbol-font-size, $checkboxInnerWidth, 'px');
+
+      text-decoration: inherit;
+      text-align: center;
+      text-transform: none;
+    }
+  }*/
+
+  legend {
+    padding: 0;
+  }
+
+  &.mandatory {
+
+    label {
+      padding-right: 15px;
+    }
+
+    &:after {
+      bottom: initial;
+      top: 0;
+    }
+  }
+}
+
+.lbl-tgl {
+  display: block;
+  position: relative;
+  z-index: 2;
+
+  color: var(--cbx-clr-label);
+  font-size: $form-checkbox-radio-label-font-size;
+  line-height: $form-checkbox-radio-label-line-height;
+
+  padding-top: $form-checkbox-radio-label-offset;
+  // Calculate offset for the label
+  padding-left: sum($form-checkbox-radio-size, 10px, 'px');
+  margin-bottom: 0;
+  min-height: $form-checkbox-radio-label-min-height;
+
+  cursor: pointer;
+
+  &:before {
+    //display: inline-block;
+    //content: '';
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    content: $form-checkbox-radio-symbol;
+
+    position: absolute;
+    top: $form-checkbox-radio-symbol-offset;
+    left: 0;
+
+    width: $form-checkbox-radio-size;
+    height: $form-checkbox-radio-size;
+
+    border-width: $form-checkbox-radio-border-width;
+    border-style: $form-checkbox-radio-border-style;
+    border-color: var(--cbx-bdr-clr);
+    border-radius: $form-checkbox-border-radius;
+
+    background-color: var(--cbx-bg-clr);
+
+    vertical-align: middle;
+  }
+
+  &:hover:before {
+    border-color: var(--cbx-bdr-clr-hvr);
+    background-color: var(--cbx-bg-clr-hvr);
+  }
+}
+
+.lbr-50 {
+
+  &:before {
+    border-radius: 50%;
   }
 }

--- a/public/framework/scss/_components/_form.scss
+++ b/public/framework/scss/_components/_form.scss
@@ -11,7 +11,7 @@
   content: '*';
 
   position: absolute;
-  top: 5px;
+  top: 0;
   right: var(--mand-r,5px);
 
   font-size: 15px;
@@ -119,45 +119,10 @@ textarea {
   line-height: $form-textarea-line-height;
 }
 
-.widget {
+// Select symbol
+.select {
 
-  &,.input-container {
-    position: relative;
-  }
-
-  // reset
-  &-textarea,
-  &-range {
-
-    .input-container {
-      font-size: 0;
-    }
-  }
-
-  // states
-  &.error {
-    --mand-clr:#{$form-input-mandatory-symbol-color-error};
-
-    p.error {
-      color: $form-input-color-error;
-      font-size: $form-input-font-size-error;
-    }
-  }
-
-  &.mandatory {
-    .input-container:after { @extend %form-mandatory-styles; }
-  }
-
-  &-checkbox,
-  &-radio,
-  &-range {
-    --mand-r:#{sum(divide($grid-gutter-small-width, 2), 5px, 'px')};
-
-    &.mandatory:after { @extend %form-mandatory-styles; }
-  }
-
-  // select-symbol
-  &.select .input-container {
+  .input-container {
 
     &:before {
       display: inline-block;
@@ -193,135 +158,50 @@ textarea {
       }
     }
   }
+}
 
-  /*// checkbox & -radio styles
+.widget {
 
-  // Calculation for checkbox and radio offsets for pseudo or text element
-  $form-checkbox-radio-label-offset:  0;
-  $form-checkbox-radio-symbol-offset: 1px;
-  $form-checkbox-radio-label-min-height: $form-checkbox-radio-size;
+  &,.input-container {
+    position: relative;
+  }
 
-  @if ($form-checkbox-radio-auto-align == 'Active') {
-    $font-min-height: multiply($form-checkbox-radio-label-font-size, $form-checkbox-radio-label-line-height);
+  // reset
+  &-textarea,
+  &-range {
 
-    @if ($form-checkbox-radio-size < $font-min-height) {
-      $form-checkbox-radio-symbol-offset: sub(divide(sub($font-min-height, $form-checkbox-radio-size), 2), 1px);
+    .input-container {
+      font-size: 0;
     }
-    @else if ($form-checkbox-radio-size > $font-min-height) {
-      $--calc-offset: sum(divide(sub($form-checkbox-radio-size, $font-min-height), 2), 1px);
+  }
 
-      $form-checkbox-radio-symbol-offset: 0;
-      $form-checkbox-radio-label-offset:  $--calc-offset;
+  // states
+  &.error {
+    --mand-clr:#{$form-input-mandatory-symbol-color-error};
+
+    p.error {
+      color: $form-input-color-error;
+      font-size: $form-input-font-size-error;
     }
-  }*/
+  }
 
-  /*&-checkbox,
-  &-radio {
+  &-checkbox,
+  &-radio,
+  &-range {
+    --mand-r:#{sum(divide($grid-gutter-small-width, 2), 5px, 'px')};
 
-    input {
-      position: absolute;
-      opacity: 0;
-      z-index: 1;
-      width: 1px;
-
-      &:checked + label {
-
-        &:before {
-          border-color: $form-checkbox-radio-border-color-focus;
-          background-color: $form-checkbox-radio-background-focus;
-        }
-
-        &:after {
-          display: inline-block;
-          content: $form-checkbox-radio-symbol;
-          font-family: $form-checkbox-radio-symbol-font-family;
-
-          position: absolute;
-          left: 1px;
-          top: $form-checkbox-radio-symbol-offset;
-
-          width: sub($form-checkbox-radio-size, 1px, 'px');
-          line-height: $form-checkbox-radio-size;
-          color: var(--cbx-symbol-clr);
-
-          // Calculation: Do not allow font-sizes bigger than the width of the the checkbox
-          $checkboxInnerWidth: sub($form-checkbox-radio-size, multiply($form-checkbox-radio-border-width, 2), 'px');
-          font-size: minUnit($form-checkbox-radio-symbol-font-size, $checkboxInnerWidth, 'px');
-
-          text-decoration: inherit;
-          text-align: center;
-          text-transform: none;
-        }
-      }
+    &.mandatory:after {
+      @extend %form-mandatory-styles;
     }
+  }
 
-    label {
-      display: block;
-      position: relative;
-      z-index: 2;
+  &.mandatory {
 
-      color: var(--cbx-clr-label);
-      font-size: $form-checkbox-radio-label-font-size;
-      line-height: $form-checkbox-radio-label-line-height;
-
-      padding-top: $form-checkbox-radio-label-offset;
-      // Calculate offset for the label
-      padding-left: sum($form-checkbox-radio-size, 10px, 'px');
-      margin-bottom: 0;
-      min-height: $form-checkbox-radio-label-min-height;
-
-      cursor: pointer;
-
-      &:before {
-        display: inline-block;
-        content: '';
-
-        position: absolute;
-        top: $form-checkbox-radio-symbol-offset;
-        left: 0;
-
-        width: $form-checkbox-radio-size;
-        height: $form-checkbox-radio-size;
-
-        border-width: $form-checkbox-radio-border-width;
-        border-style: $form-checkbox-radio-border-style;
-        border-color: var(--cbx-bdr-clr);
-        border-radius: $form-checkbox-border-radius;
-
-        background-color: var(--cbx-bg-clr);
-
-        vertical-align: middle;
-      }
-
-      &:hover:before {
-        border-color: var(--cbx-bdr-clr-hvr);
-        background-color: var(--cbx-bg-clr-hvr);
-      }
+    .input-container:after {
+      top: 5px;
+      @extend %form-mandatory-styles;
     }
-
-    legend {
-      padding: 0;
-    }
-
-    &.mandatory {
-
-      label {
-        padding-right: 15px;
-      }
-
-      &:after {
-        bottom: initial;
-        top: 0;
-      }
-    }
-  }*/
-
-  /*&-radio {
-
-    label:before {
-      border-radius: 50%;
-    }
-  }*/
+  }
 
   &-range {
 
@@ -382,7 +262,7 @@ textarea {
   }
 }
 
-// checkbox & -radio styles
+// Checkbox & -radio styles
 
 // Calculation for checkbox and radio offsets for pseudo or text element
 $form-checkbox-radio-label-offset:  0;
@@ -403,60 +283,7 @@ $form-checkbox-radio-label-min-height: $form-checkbox-radio-size;
   }
 }
 
-[type=radio],
-[type=checkbox] {
-  position: absolute;
-  opacity: 0;
-  z-index: 1;
-  width: 1px;
-
-  /*&:checked + label {
-
-    &:before {
-      border-color: $form-checkbox-radio-border-color-focus;
-      background-color: $form-checkbox-radio-background-focus;
-    }
-
-    &:after {
-      display: inline-block;
-      content: $form-checkbox-radio-symbol;
-      font-family: $form-checkbox-radio-symbol-font-family;
-
-      position: absolute;
-      left: 1px;
-      top: $form-checkbox-radio-symbol-offset;
-
-      width: sub($form-checkbox-radio-size, 1px, 'px');
-      line-height: $form-checkbox-radio-size;
-      color: var(--cbx-symbol-clr);
-
-      // Calculation: Do not allow font-sizes bigger than the width of the the checkbox
-      $checkboxInnerWidth: sub($form-checkbox-radio-size, multiply($form-checkbox-radio-border-width, 2), 'px');
-      font-size: minUnit($form-checkbox-radio-symbol-font-size, $checkboxInnerWidth, 'px');
-
-      text-decoration: inherit;
-      text-align: center;
-      text-transform: none;
-    }
-  }*/
-
-  legend {
-    padding: 0;
-  }
-
-  &.mandatory {
-
-    label {
-      padding-right: 15px;
-    }
-
-    &:after {
-      bottom: initial;
-      top: 0;
-    }
-  }
-}
-
+// Label toggle
 .lbl-tgl {
   display: block;
   position: relative;
@@ -475,16 +302,22 @@ $form-checkbox-radio-label-min-height: $form-checkbox-radio-size;
   cursor: pointer;
 
   &:before {
-    //display: inline-block;
-    //content: '';
+    content: '';
+
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    content: $form-checkbox-radio-symbol;
+
+    font-family: $form-checkbox-radio-symbol-font-family;
+    // Calculation: Do not allow font-sizes bigger than the width of the the checkbox
+    $checkboxInnerWidth: sub($form-checkbox-radio-size, multiply($form-checkbox-radio-border-width, 2), 'px');
+    font-size: minUnit($form-checkbox-radio-symbol-font-size, $checkboxInnerWidth, 'px');
 
     position: absolute;
     top: $form-checkbox-radio-symbol-offset;
     left: 0;
+
+    color: var(--cbx-symbol-clr);
 
     width: $form-checkbox-radio-size;
     height: $form-checkbox-radio-size;
@@ -505,9 +338,42 @@ $form-checkbox-radio-label-min-height: $form-checkbox-radio-size;
   }
 }
 
+// Label border-radius
 .lbr-50 {
 
   &:before {
     border-radius: 50%;
+  }
+}
+
+// Checkbox radio toggle (Input)
+.crt {
+  position: absolute;
+  opacity: 0;
+  z-index: 1;
+  width: 1px;
+
+  &:checked + label {
+
+    &:before {
+      content: $form-checkbox-radio-symbol;
+      border-color: $form-checkbox-radio-border-color-focus;
+      background-color: $form-checkbox-radio-background-focus;
+    }
+  }
+}
+
+// Checkbox radio container
+.crc {
+
+  legend {
+    padding: 0;
+  }
+
+  .mandatory & {
+
+    label {
+      padding-right: 15px;
+    }
   }
 }

--- a/public/framework/scss/_components/_form.scss
+++ b/public/framework/scss/_components/_form.scss
@@ -31,7 +31,7 @@
 
 label,
 legend {
-  display: inline-block;
+  //display: inline-block;
   color: var(--form-clr-label);
   font-size: $form-label-font-size;
   margin-bottom: $form-label-spacing;
@@ -133,12 +133,13 @@ textarea {
       bottom: #{divide(sub($form-input-height, $form-select-symbol-font-size, 'px'), 2)};
       right: 12px;
 
-      line-height: 1;
-      height: 1em;
-      width: 1em;
       font-size: $form-select-symbol-font-size;
+      line-height: 1;
+      //height: 1em;
+      //width: 1em;
 
-      text-align: center;
+
+      //text-align: center;
       text-decoration: inherit;
       text-transform: none;
 


### PR DESCRIPTION
This PR simplifies form components and their pseudo elements that were used

- checkboxes and radio buttons only use one pseudoelement with content (no more :after needed)
- decreased size of the form component css
- simplified selectors by adding classes to the form components in question
- removed the obsolete "pfield" class