### PR TITLE
Rework gutter (core 2-0)

### DIFF
--- a/contao/languages/de/tl_thememanager.xlf
+++ b/contao/languages/de/tl_thememanager.xlf
@@ -1670,22 +1670,6 @@
         <source>Here you can set the vertical padding for each grid-element.</source>
         <target>Hier können Sie das vertikale Polster (padding) für Grid-Elemente einstellen.</target>
       </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-width.0">
-        <source>$grid-gutter-small-width</source>
-        <target>$grid-gutter-small-width</target>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-width.1">
-        <source>Here you can set the small horizontal padding for each grid-element.</source>
-        <target>Hier können Sie das kleine horizontale Polster (padding) für Grid-Elemente einstellen.</target>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-bottom.0">
-        <source>$grid-gutter-small-bottom</source>
-        <target>$grid-gutter-small-bottom</target>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-bottom.1">
-        <source>Here you can set the small vertical padding for each grid-element.</source>
-        <target>Hier können Sie das kleine vertikale Polster (padding) für Grid-Elemente einstellen.</target>
-      </trans-unit>
 
       <trans-unit id="tl_thememanager.form-input-font-family.0">
         <source>$form-input-font-family</source>

--- a/contao/languages/en/tl_thememanager.xlf
+++ b/contao/languages/en/tl_thememanager.xlf
@@ -1265,18 +1265,6 @@
       <trans-unit id="tl_thememanager.grid-gutter-bottom.1">
         <source>Here you can set the vertical padding for each grid-element.</source>
       </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-width.0">
-        <source>$grid-gutter-small-width</source>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-width.1">
-        <source>Here you can set the small horizontal padding for each grid-element.</source>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-bottom.0">
-        <source>$grid-gutter-small-bottom</source>
-      </trans-unit>
-      <trans-unit id="tl_thememanager.grid-gutter-small-bottom.1">
-        <source>Here you can set the small vertical padding for each grid-element.</source>
-      </trans-unit>
 
       <trans-unit id="tl_thememanager.form-input-font-family.0">
         <source>$form-input-font-family</source>

--- a/contao/templates/js/js_ctm_core.html5
+++ b/contao/templates/js/js_ctm_core.html5
@@ -1,0 +1,1 @@
+<?php $GLOBALS['TL_HEAD'][] = "<script>new ResizeObserver(e=>{e[0].target.style.setProperty('--lvw',e[0].contentBoxSize[0].inlineSize + 'px')}).observe(document.documentElement)</script>";

--- a/contao/templates/theme-manager-config.html5
+++ b/contao/templates/theme-manager-config.html5
@@ -9,7 +9,7 @@
             '{link_legend:hide},link-font-weight,link-color-regular,link-hover-color-regular,link-decoration-regular,link-hover-decoration-regular,link-color-invert,link-hover-color-invert,link-decoration-invert,link-hover-decoration-invert,link-color-extra,link-hover-color-extra,link-decoration-extra,link-hover-decoration-extra;' .
             '{layout_legend:hide},breakpoints,layout-column-small-break,layout-column-medium-break,layout-column-large-break,layout-column-width-small,layout-column-width-medium,layout-column-width-large,layout-column-gutter-small,layout-column-gutter-medium,layout-column-gutter-large;' .
             '{article_legend:hide},x-spacing-large-m,x-spacing-large-l,x-spacing-small,article-outer-padding,article-outer-padding-xs,article-outer-padding-s,article-spacing-xs-small,article-spacing-s-small,article-spacing-m-small,article-spacing-l-small,article-spacing-xl-small,article-spacing-xs-medium,article-spacing-s-medium,article-spacing-m-medium,article-spacing-l-medium,article-spacing-xl-medium,article-spacing-xs-large,article-spacing-s-large,article-spacing-m-large,article-spacing-l-large,article-spacing-xl-large,article-min-vheight,article-options-vheight;' .
-            '{grid_legend:hide},grid-columns,grid-gutter-width,grid-gutter-bottom,grid-gutter-small-width,grid-gutter-small-bottom;' .
+            '{grid_legend:hide},grid-columns,grid-gutter-width,grid-gutter-bottom;' .
             '{form_general_legend:hide},form-input-font-family,form-textarea-line-height,form-input-padding,form-input-height,form-multiselect-height,form-input-font-weight,form-input-font-size,form-input-font-size-error,form-input-border-radius,form-input-border-width,form-input-border-style,form-input-border-color,form-input-border-color-hover,form-input-border-color-focus,form-input-border-color-error,form-input-background,form-input-background-hover,form-input-background-focus,form-input-background-error,form-input-color,form-input-color-hover,form-input-color-focus,form-input-color-error,form-input-placeholder-color,form-input-placeholder-color-hover,form-input-placeholder-color-focus,form-input-placeholder-color-error,form-input-color-disabled;' .
             '{form_label_legend:hide},form-label-color,form-label-color-invert,form-label-font-size,form-label-spacing,form-label-font-weight,form-legend-font-weight;' .
             '{form_select_legend:hide},form-select-symbol,form-select-symbol-font-size,form-select-symbol-color,form-select-symbol-font-family,form-select-option-color,form-select-option-background;' .
@@ -1315,35 +1315,21 @@
             'default'                 => '12',
             'label'                   => &$GLOBALS['TL_LANG']['tl_thememanager']['grid-columns'],
             'inputType'               => 'text',
-            'eval'                    => ['placeholder'=>'12', 'rgxp'=>'natural', 'minval'=>1, 'maxval'=>24, 'maxlength'=>2, 'tl_class'=>'clr'],
+            'eval'                    => ['placeholder'=>'12', 'rgxp'=>'natural', 'minval'=>1, 'maxval'=>24, 'maxlength'=>2, 'tl_class'=>'w33 clr'],
         ],
         'grid-gutter-width' => [
             'default'                 => 'a:2:{s:4:"unit";s:3:"rem";s:5:"value";s:1:"2";}',
             'label'                   => &$GLOBALS['TL_LANG']['tl_thememanager']['grid-gutter-width'],
             'inputType'               => 'inputUnit',
             'options'                 => $GLOBALS['CTM_CSS_UNITS'],
-            'eval'                    => ['placeholder'=>'2rem', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w50 clr'],
+            'eval'                    => ['placeholder'=>'2rem', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w33'],
         ],
         'grid-gutter-bottom' => [
             'default'                 => 'a:2:{s:4:"unit";s:0:"";s:5:"value";s:18:"$grid-gutter-width";}',
             'label'                   => &$GLOBALS['TL_LANG']['tl_thememanager']['grid-gutter-bottom'],
             'inputType'               => 'inputUnit',
             'options'                 => $GLOBALS['CTM_CSS_UNITS'],
-            'eval'                    => ['placeholder'=>'$grid-gutter-width', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w50'],
-        ],
-        'grid-gutter-small-width' => [
-            'default'                 => 'a:2:{s:4:"unit";s:3:"rem";s:5:"value";s:1:"1";}',
-            'label'                   => &$GLOBALS['TL_LANG']['tl_thememanager']['grid-gutter-small-width'],
-            'inputType'               => 'inputUnit',
-            'options'                 => $GLOBALS['CTM_CSS_UNITS'],
-            'eval'                    => ['placeholder'=>'1rem', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w50'],
-        ],
-        'grid-gutter-small-bottom' => [
-            'default'                 => 'a:2:{s:4:"unit";s:0:"";s:5:"value";s:24:"$grid-gutter-small-width";}',
-            'label'                   => &$GLOBALS['TL_LANG']['tl_thememanager']['grid-gutter-small-bottom'],
-            'inputType'               => 'inputUnit',
-            'options'                 => $GLOBALS['CTM_CSS_UNITS'],
-            'eval'                    => ['placeholder'=>'$grid-gutter-small-width', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w50'],
+            'eval'                    => ['placeholder'=>'$grid-gutter-width', 'includeBlankOption'=>true, 'rgxp'=>'digit_inherit', 'maxlength'=>32, 'tl_class'=>'w33'],
         ],
 
         // Form general

--- a/public/framework/scss/_base/_vars.scss
+++ b/public/framework/scss/_base/_vars.scss
@@ -55,11 +55,9 @@
   --gtr:#{$grid-gutter-width};
   --gtr-btm:#{$grid-gutter-bottom};
 
-  --gtr-sml:#{$grid-gutter-small-width};
-  --gtr-btm-sml:#{$grid-gutter-small-bottom};
-
   --gtr-half:#{divide($grid-gutter-width, 2)};
-  --gtr-half-sml:#{divide($grid-gutter-small-width, 2)};
+  --gtr-half-sml:#{divide($grid-gutter-width, 4)};
+  --gtr-half-btm:#{divide($grid-gutter-bottom,2)};
 
   // Layout
   --mx-1:#{$left-right-margin-small};

--- a/public/framework/scss/_components/_form.scss
+++ b/public/framework/scss/_components/_form.scss
@@ -182,7 +182,7 @@ textarea {
   &-checkbox,
   &-radio,
   &-range {
-    --mand-r:#{sum(divide($grid-gutter-small-width, 2), 5px, 'px')};
+    --mand-r:#{sum(divide($grid-gutter-width, 4), 5px, 'px')};
 
     &.mandatory:after {
       @extend %form-mandatory-styles;

--- a/public/framework/scss/_components/_list.scss
+++ b/public/framework/scss/_components/_list.scss
@@ -20,7 +20,7 @@ li {
 }
 
 .c_list {
-  &.gtr-1     {--i-v-gap:calc(var(--gtr-btm-sml)/2);}
+  &.gtr-1     {--i-v-gap:calc(var(--gtr-half-btm)/2);}
   &.gtr-2     {--i-v-gap:calc(var(--gtr-btm)/2);}
   &.flow-y    {--i-v-gap:#{rem(3)};--h-gap:0;}
   &.flow-auto {--i-v-gap: 0;--h-gap:var(--v-gap);justify-content:var(--justify);};

--- a/public/framework/scss/_components/_text.scss
+++ b/public/framework/scss/_components/_text.scss
@@ -16,6 +16,11 @@
       }
     }
   }
+
+  // Consider nested text blocks (e.g. news bundle)
+  .c_text & {
+    margin-bottom: $paragraph-spacing;
+  }
 }
 
 @include media-breakpoint('xs') {

--- a/public/framework/scss/_config.scss
+++ b/public/framework/scss/_config.scss
@@ -249,8 +249,6 @@ $layout-column-gutter-large:                  3rem !default;
 $grid-columns:                                12 !default;
 $grid-gutter-width:                           2rem !default;
 $grid-gutter-bottom:                          $grid-gutter-width !default;
-$grid-gutter-small-width:                     1rem !default;
-$grid-gutter-small-bottom:                    $grid-gutter-small-width !default;
 
 // Form general
 $form-input-font-family:                      var(--font-family) !default;

--- a/public/framework/scss/_layout/_article-spacing.scss
+++ b/public/framework/scss/_layout/_article-spacing.scss
@@ -1,225 +1,126 @@
-// Class names
-$class-horizontal-article-spacing:   'art-px';
-$class-vertical-article-spacing:     'art-py';
-$class-vertical-article-spacing-top: 'art-pt';
-$class-vertical-article-spacing-btm: 'art-pb';
-
-$class-article-overlap-self:         'art-ol-self';
-$class-article-overlap-next:         'art-ol-next';
-
-$art-space-abbr: (
-  width:    art-wdth,
-  xpadding: art-ox,
-  xspacing: art-px,
-  yspacing: art-py,
-  1: 1,
-  2: 2,
-  3: 3
-);
-
 // Y-spacings (vertical top and bottom)
 $spacings-list-init: (
-  1: $article-spacing-xs-small,
-  2: $article-spacing-xs-medium,
-  3: $article-spacing-xs-large
+       1: $article-spacing-xs-small, 2: $article-spacing-xs-medium, 3: $article-spacing-xs-large
 );
 
 $spacings-list-bp: (
-  s: (
-    1: $article-spacing-s-small,
-    2: $article-spacing-s-medium,
-    3: $article-spacing-s-large
-  ),
-  m: (
-    1: $article-spacing-m-small,
-    2: $article-spacing-m-medium,
-    3: $article-spacing-m-large
-  ),
-  l: (
-    1: $article-spacing-l-small,
-    2: $article-spacing-l-medium,
-    3: $article-spacing-l-large
-  ),
-  xl: (
-    1: $article-spacing-xl-small,
-    2: $article-spacing-xl-medium,
-    3: $article-spacing-xl-large
-  )
+  s:  (1: $article-spacing-s-small,  2: $article-spacing-s-medium,  3: $article-spacing-s-large),
+  m:  (1: $article-spacing-m-small,  2: $article-spacing-m-medium,  3: $article-spacing-m-large),
+  l:  (1: $article-spacing-l-small,  2: $article-spacing-l-medium,  3: $article-spacing-l-large),
+  xl: (1: $article-spacing-xl-small, 2: $article-spacing-xl-medium, 3: $article-spacing-xl-large)
 );
-
-$abbr-wdth:  map-get($art-space-abbr, width);
-$abbr-pad-x: map-get($art-space-abbr, xpadding);
-$abbr-spc-x: map-get($art-space-abbr, xspacing);
-$abbr-spc-y: map-get($art-space-abbr, yspacing);
 
 // Add default bottom-padding to #main articles
 main .article_inside {
   padding-bottom: var(--v-gap);
 }
 
-.article_inside {
-  // Add default bottom-padding to #main articles
-  main & {
-    padding-bottom: var(--v-gap);
+.grid > .article_inside {
+  margin-left: 0;
+  margin-right: 0;
+
+  .gtr-0&{
+    > .ce_wrapper {--gtr-x:var(--h-gap);} // Always reset gtr-0 within wrapper
+    > .gtr-1      {--gtr-x:var(--gtr);} // Set normal gutter for gtr-1
   }
 }
 
 // Article overlaps
-[class*=#{$class-article-overlap-self}] {
+[class*=art-ol-self] + * > .inside { position: relative; z-index: 1; }
+[class*=art-ol-next] > .inside     { position: relative; z-index: 1; }
 
-  + * {
-
-    > .inside {
-      position: relative;
-      z-index: 1;
-    }
-  }
+.article_inside,
+#container > .inside {
+  padding-left:  calc(var(--art-px, 0px) + var(--art-ox, 0px));
+  padding-right: calc(var(--art-px, 0px) + var(--art-ox, 0px));
 }
 
-[class*=#{$class-article-overlap-next}] {
-
-  > .inside {
-    position: relative;
-    z-index: 1;
-  }
+.mod_article:not([class*=art-px]) {
+  --art-ox:0px!important;
 }
 
-[class*=#{$class-horizontal-article-spacing}] {
-
-  &, #container {
-
-    > .inside {
-      max-width:     var(--#{$abbr-wdth}, auto);
-      padding-left:  calc(var(--#{$abbr-spc-x},0px) + var(--#{$abbr-pad-x},0px));
-      padding-right: calc(var(--#{$abbr-spc-x},0px) + var(--#{$abbr-pad-x},0px));
-      margin-left:   auto;
-      margin-right:  auto;
-    }
-  }
-
-  &.gtr-1 {
-    --#{$abbr-spc-x}: #{divide(sub($grid-gutter-width, $grid-gutter-small-width), 2)};
-  }
-
-  &.gtr-0 {
-    --#{$abbr-spc-x}: #{divide($grid-gutter-width, 2)};
-  }
+.gtr-1 {
+  --art-px:#{divide($grid-gutter-width, 4)};
 }
 
-// Set custom properties
+// Set outer padding for no gutter when x-spacing is set
+.gtr-0[class*=art-px] {
+  --art-px:#{divide($grid-gutter-width,2)};
+}
+
 :root {
-  --#{$abbr-pad-x}:#{$article-outer-padding};
-  @each $size, $spacing in $spacings-list-init {
-    --#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)}: #{$spacing};
-  }
+  --art-ox:#{$article-outer-padding};
+  --art-py-1:#{$article-spacing-xs-small};
+  --art-py-2:#{$article-spacing-xs-medium};
+  --art-py-3:#{$article-spacing-xs-large};
 }
 
 @each $size, $spacing in $spacings-list-init {
-  .#{$class-vertical-article-spacing}-#{$size} {
-    $v-art-pd: #{$abbr-spc-y}-#{map-get($art-space-abbr, $size)};
+  .art-py-#{$size} {
     &, #container {
       > .inside {
-        padding-top:    var(--#{$v-art-pd});
-        padding-bottom: var(--#{$v-art-pd});
+        padding-top:    var(--art-py-#{$size});
+        padding-bottom: var(--art-py-#{$size});
       }
     }
   }
 }
 
 @each $size, $spacing in $spacings-list-init {
-  .#{$class-vertical-article-spacing-top}-#{$size} {
-    > .inside {
-      padding-top: var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)});
+  .art-pt-#{$size} > .inside { padding-top: var(--art-py-#{$size}); }
+  .art-pb-#{$size} > .inside { padding-bottom: var(--art-py-#{$size}); }
+  .art-ol-self-#{$size} {
+    padding-bottom: var(--art-py-#{$size});
+    + * { margin-bottom: calc(var(--art-py-#{$size}) * -1);
+      > .inside { top: calc(var(--art-py-#{$size}) * -1);}
     }
   }
-  .#{$class-vertical-article-spacing-btm}-#{$size} {
-    > .inside {
-      padding-bottom: var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)});
-    }
-  }
-  .#{$class-article-overlap-self}-#{$size} {
-    padding-bottom: var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)});
-    + * { margin-bottom: calc(var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)}) * -1);
-      > .inside { top: calc(var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)}) * -1);}
-    }
-  }
-  .#{$class-article-overlap-next}-#{$size} {
-    margin-top: calc(var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)}) * -1);
-    > .inside { top: var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)});}
-    + * { padding-top: var(--#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)});}
+  .art-ol-next-#{$size} {
+    margin-top: calc(var(--art-py-#{$size}) * -1);
+    > .inside { top: var(--art-py-#{$size});}
+    + * { padding-top: var(--art-py-#{$size});}
   }
 }
 
 @each $bp in map-keys($breakpoints) {
   $infix: breakpoint-infix($bp);
-  @include media-breakpoint($bp) {
-
-    $list: map-get($spacings-list-bp, $bp);
-
-    @if ($bp == 'xs') {
-      :root {--#{$abbr-pad-x}:#{$article-outer-padding-xs};}
+  $list: map-get($spacings-list-bp, $bp);
+  @if ($bp == 'l') {
+    $bp-l-gtr-none: sub(map-get($breakpoints,$bp),$grid-gutter-width,'px');
+    @media (min-width:$bp-l-gtr-none) {
+      .art-px-2 {--art-wdth:#{$bp-l-gtr-none};}
+      .art-px-3 {--art-wdth:#{$x-spacing-large-l};}
+      .mx-art {--art-mx:calc((max(var(--lvw,100lvw),#{$bp-l-gtr-none}) - #{$bp-l-gtr-none}) / 2);}
+      .gtr-0 > .article_inside .mx-art {--art-mx:calc(((max(var(--lvw,100lvw),#{$bp-l-gtr-none}) - #{$bp-l-gtr-none}) / 2) + #{divide($grid-gutter-width,2)});}
+      .ce_wrapper.grid:not(.gtr-0) > .mx-art {--art-mx:calc(((max(var(--lvw,100lvw),#{$bp-l-gtr-none}) - #{$bp-l-gtr-none}) / 2) - (var(--gtr-x) / 2));}
+      .ml-art { margin-left:var(--art-mx)!important }
+      .mr-art { margin-right:var(--art-mx)!important }
     }
-
+  }
+  @include media-breakpoint($bp) {
+    @if ($bp == 'xs') {:root {--art-ox:#{$article-outer-padding-xs};}}
     @if map-has-key($spacings-list-bp, $bp) {
       :root {
-        @if ($bp == 's') {--#{$abbr-pad-x}:#{$article-outer-padding-s};}
-        @each $size, $spacing in $list {
-          --#{$abbr-spc-y}-#{map-get($art-space-abbr, $size)}: #{$spacing};
-        }
+        @if ($bp == 's') {--art-ox:#{$article-outer-padding-s};}
+        @if ($bp == 'm') {--art-ox:0px;}
+        @each $size, $spacing in $list {--art-py-#{$size}:#{$spacing};}
       }
     }
-
     @if ($bp == 'm') {
-      .#{$class-horizontal-article-spacing} {
-
-        &-#{map-get($art-space-abbr, 3)} {
-          --#{$abbr-pad-x}:0px;
-          --#{$abbr-wdth}: #{$x-spacing-large-m};
-        }
-      }
-    }
-
-    @else if ($bp == 'l') {
-      [class*=#{$class-horizontal-article-spacing}].gtr-1 {
-        --art-px:0px;
-      }
-
-      .#{$class-horizontal-article-spacing} {
-
-        &-#{map-get($art-space-abbr, 2)} {
-          --#{$abbr-pad-x}:0px;
-          --#{$abbr-wdth}:#{sub(map-get($breakpoints, $bp), $grid-gutter-width,'px')};
-
-          &.gtr-1 {
-            --#{$abbr-wdth}:#{sub(map-get($breakpoints, $bp), $grid-gutter-small-width,'px')};
+      .art-px-3 {--art-wdth:#{$x-spacing-large-m};}
+      [class*=art-px] {
+        &, #container {
+          > .inside {
+            max-width: var(--art-wdth, auto);
+            margin-left: auto !important;
+            margin-right: auto !important;
           }
         }
-
-        &-#{map-get($art-space-abbr, 3)} {
-          --#{$abbr-wdth}:#{$x-spacing-large-l};
-        }
       }
-
-      // Special element offset for medium left/right spacing
-      .mx-art {
-        --art-mx:calc((100vw - var(--mx-off,#{sub(map-get($breakpoints,$bp),divide($grid-gutter-width,2))})) / 2);
-        .mod_article .ce_wrapper.grid & {--mx-off:#{sub(map-get($breakpoints,$bp),divide($grid-gutter-width,2))};}
-        .mod_article.gtr-1 &, .ce_wrapper.grid.gtr-1 & {--mx-off:#{rem(map-get($breakpoints,$bp))};}
-        .mod_article.gtr-0 &, .ce_wrapper.grid.gtr-0 & {--mx-off:#{sub(map-get($breakpoints,$bp),sum($grid-gutter-width,divide($grid-gutter-width,2)))};}
-      }
-
-      .ml-art { margin-left: var(--art-mx)!important; }
-      .mr-art { margin-right: var(--art-mx)!important; }
     }
   }
 }
 
-@media (min-width: sum($x-spacing-small, $grid-gutter-width,'px')) {
-  .#{$class-horizontal-article-spacing} {
-
-    &-#{map-get($art-space-abbr, 1)} {
-      --#{$abbr-pad-x}:0px;
-      --#{$abbr-wdth}:#{$x-spacing-small};
-    }
-  }
+@media (min-width: $x-spacing-small) {
+  .art-px-1 {--art-wdth:#{$x-spacing-small};}
 }

--- a/public/framework/scss/_layout/_article.scss
+++ b/public/framework/scss/_layout/_article.scss
@@ -8,16 +8,6 @@
   }
 }
 
-/*@media (min-height: $article-min-vheight) {
-
-  .mod_article {
-
-    > .inside {
-      min-height: var(--art-hght)
-    }
-  }
-}*/
-
 [class*=a-vh-] {
   --dock:0px;
   --art-hght:calc(var(--a-vh) - var(--dock));
@@ -30,6 +20,6 @@
 @if type-of($article-options-vheight) == list {
 
   @each $height in $article-options-vheight {
-    .a-vh-#{$height} {--a-vh:#{$height}vh;}
+    .a-vh-#{$height} {--a-vh:#{$height}dvh;}
   }
 }

--- a/public/framework/scss/_layout/_grid/_grid-framework.scss
+++ b/public/framework/scss/_layout/_grid/_grid-framework.scss
@@ -1,14 +1,13 @@
 .grid {
   --v-gap:var(--gtr-btm);
+  --h-gap:var(--gtr);
   --justify:normal;
   --flex-items:normal;
 
   > .inside {
-    // Negative margin to counter offset
-    margin-left:  var(--h-gap-off,0);
-    margin-right: var(--h-gap-off,0);
-
-    --i-gtr:var(--gtr-half);
+    --gtr-x:var(--gtr);
+    margin-left:  calc(var(--gtr-x) * -.5);
+    margin-right: calc(var(--gtr-x) * -.5);
 
     position: relative;
 
@@ -27,13 +26,8 @@
       flex-basis:  100%;
       max-width:   100%;
 
-      padding-right: var(--i-gtr);
-      padding-left:  var(--i-gtr);
-    }
-
-    // Nested grids
-    > .grid {
-      --h-gap-off:calc(-1 * var(--i-gtr));
+      padding-right: calc(var(--gtr-x) * .5);
+      padding-left:  calc(var(--gtr-x) * .5);
     }
   }
 }

--- a/public/framework/scss/_layout/_grid/_grid-gutter.scss
+++ b/public/framework/scss/_layout/_grid/_grid-gutter.scss
@@ -2,12 +2,11 @@
 
   // Form specific gutter
   &-f {
-    --v-gap:var(--gtr-btm-sml);
-    --h-gap:var(--gtr-sml);
+    --v-gap:var(--gtr-half-btm);
+    --h-gap:var(--gtr-half);
 
     > .inside {
-      --i-gtr:var(--gtr-half-sml);
-      --h-gap-off:calc(-1 * var(--i-gtr));
+      --gtr-x:var(--gtr-half);
     }
   }
 
@@ -16,27 +15,25 @@
     --h-gap:var(--gtr);
 
     > .inside {
-      --i-gtr:var(--gtr-half);
+      --gtr-x:var(--gtr);
     }
   }
 
-  // Small gutter
   &-1 {
-    --v-gap:var(--gtr-btm-sml);
-    --h-gap:var(--gtr-sml);
+    --v-gap:var(--gtr-half-btm);
+    --h-gap:var(--gtr-half);
 
     > .inside {
-      --i-gtr:var(--gtr-half-sml);
+      --gtr-x:var(--gtr-half);
     }
   }
 
-  // No gutter
   &-0 {
     --v-gap:0rem;
     --h-gap:0rem;
 
     > .inside {
-      --i-gtr:0rem;
+      --gtr-x:0rem;
     }
   }
 }

--- a/public/framework/scss/_layout/_layout.scss
+++ b/public/framework/scss/_layout/_layout.scss
@@ -77,6 +77,18 @@
 #right,
 #left {
   order: 15;
+
+  // Reset grid
+  > .inside {
+    margin-left: revert;
+    margin-right: revert;
+  }
+
+  // Reset articles
+  .mod_article {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .right-first #right,
@@ -105,6 +117,7 @@
   #left,
   #right {
     width: calc(var(--lyt-col-wdth) + var(--lyt-col-gtr));
+    min-width: calc(var(--lyt-col-wdth) + var(--lyt-col-gtr));;
   }
 
   #left {


### PR DESCRIPTION
<h3>Removal</h3>

- Removed `$grid-gutter-small` & `$grid-gutter-small-bottom` https://github.com/contao-thememanager/core/commit/5be57f5cbf28867010b2eb7167064864114d2396
  > Small gutter (gtr-1) is now always half of the normal grid gutter
  > You can now add your own gutter via the --gtr-x (horizontal) and --v-gap (vertical) properties



<h3>Rework</h3>

- Now using dynamic viewport height for article-vh https://github.com/contao-thememanager/core/commit/994134d4ee840607bf1a4338cc4cf77722110936
  > See https://web.dev/viewport-units/ for more information

- Reworked Grid-Framework to properly allow multi-nested grid inheritance with grid-gutter https://github.com/contao-thememanager/core/commit/c99d19bc2833a21d99c5cfba4705ec8e80b18aeb https://github.com/contao-thememanager/core/commit/a83fdaf5bfa38c2bcb9daf469da9efd7247846bb
  > This also fixes an issue with grid not properly working for embedding nested modules within left/right aside containers

- Consider nested text blocks for paragraph spacing https://github.com/contao-thememanager/core/commit/6e2227f2b8de174dc7c738994ac5f43dc4850bac 
  > In some cases, text components would be embedded into another text component completely ignoring paragraph spacings 
 due to content elements within news details etc.

- Reworked article spacings to be properly aligned despite different gutter sizes 
  > - gtr-1 will always have at least a medium gutter left and right (on mobile)
  > - gtr-0 and multi-nested wrappers properly inherit gutter within
  > - using the template js_ctm-core will introduce the real inner viewport width without a scrollbar when using the automatic margin-left and margin-right spacing to simulate article-spacing-medium
  > - gtr-1 and gtr-0 container sizes will now always be the same as gtr-2 when article-spacing left/right have been selected

- Small gutter now always has at least a medium-gutter outer padding on small devices https://github.com/contao-thememanager/core/commit/16bf2ecec2f09d9e9a25bb4c9ecaffd866219b3d



<h3>Addition</h3>

- Added --lvh as a property that can be used to get the real viewport width excluding the scrollbar https://github.com/contao-thememanager/core/commit/5ee8bdb89478d444c75eeaf90925ddb41d3f8c61
  > Use the js_ctm_core template within your layout to add this property
  > Reasoning: https://www.w3.org/TR/css-values-3/#viewport-relative-lengths - [...] However, any scrollbars are assumed not to exist

