### PR TITLE
Consider all bottom spacings within *_full templates

### DIFF
--- a/contao/templates/events/event_full.html5
+++ b/contao/templates/events/event_full.html5
@@ -9,7 +9,7 @@
       </div>
     <?php endif; ?>
 
-    <div class="c_text">
+    <div class="c_text<?= $this->details ? ' grid':''?>">
       <p class="info">
         <?php if ($this->recurring): ?>
           <span class="recurring"><?= $this->recurring ?></span>
@@ -24,7 +24,9 @@
       <h1><?= $this->title ?></h1>
 
       <?php if ($this->details): ?>
-        <?= $this->details ?>
+        <div class="inside">
+          <?= $this->details ?>
+        </div>
       <?php else: ?>
         <?= method_exists($this, 'cspInlineStyles') ? $this->cspInlineStyles($this->teaser) : $this->teaser ?>
       <?php endif; ?>

--- a/contao/templates/news/news_full.html5
+++ b/contao/templates/news/news_full.html5
@@ -9,7 +9,7 @@
       </div>
     <?php endif; ?>
 
-    <div class="c_text">
+    <div class="c_text<?= $this->hasText ? ' grid':''?>">
       <?php if ($this->hasMetaFields || (null === $this->hasMetaFields)): // Contao 5.* BC layer for simultaneous Contao 4.13 support ?>
         <?php $this->block('info'); ?>
           <p class="info">
@@ -31,7 +31,9 @@
       <?php endif; ?>
 
       <?php if ($this->hasText): ?>
-        <?= $this->text ?>
+        <div class="inside">
+          <?= $this->text ?>
+        </div>
       <?php else: ?>
         <?= method_exists($this, 'cspInlineStyles') ? $this->cspInlineStyles($this->teaser) : $this->teaser ?>
       <?php endif; ?>

--- a/public/framework/scss/ctm_components/_text.scss
+++ b/public/framework/scss/ctm_components/_text.scss
@@ -4,9 +4,17 @@
     width: var(--img-wdth, 100%);
     margin: var(--img-mt,0) var(--img-mr,0) var(--img-mb,0) var(--img-ml,0);
   }
+}
 
-  // Consider nested text blocks (e.g. news bundle)
-  .c_text & {
+// Consider nested text blocks (e.g. news bundle)
+.c_text {
+
+  &.grid {
+    --v-gap:#{$paragraph-spacing};
+  }
+
+  // BC-layer (see #37)
+  > .ce_text {
     margin-bottom: $paragraph-spacing;
   }
 }


### PR DESCRIPTION
### Description

This PR addresses the issue when using other content-elements than text within detail pages.
Previously we've used something like this but that would not work for other elements:
```css
.c_text .ce_text { margin-bottom: 1rem; }
```

### BC-layer

To allow already overriden templates to still work the same, the following line has not been removed. It however is more specific to not style the new `grid` that comes in this PR.
```css
.c_text > .ce_text { margin-bottom: 1rem; }
```

### Solution

Whilst twig is not yet implemented for news and events, we do have the possibility to check whether there is content-elements within the two types within their `*_full.html` templates. It's the case whenever `$this->hasText` or `$this->details` are.

If either is true (for events or news), I create a `grid` for the text-container and wrap the `content-elements` with an `inside`, activating the grid functionality for these elements.

```php
<div class="c_text<?= $this->details ? ' grid':''?>">
  <p class="info">...</p>
  <h1><?= $this->title ?>...</h1>
  
  <?php if ($this->details): ?>
    <div class="inside">
      <?= $this->details ?>
    </div>
  <?php else: ?>
    <?= $this->teaser ?>
  <?php endif; ?>
</div>
```

(This also makes it possible to use columns and offset for those content-elements now ;) )

The vertical gap is still the same as `$paragraph-spacing` (default: 1rem).
Should we now tie it to `article-main-spacing-bottom` or introduce a new config-variable @doishub ?