### PR TITLE
Fix Doctrine DBAL 4 type errors in migrations

### DIFF
--- a/src/Migration/Version200/ArticleSpacingMigration.php
+++ b/src/Migration/Version200/ArticleSpacingMigration.php
@@ -30,7 +30,7 @@ class ArticleSpacingMigration extends AbstractMigration
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        if (!$schemaManager->tablesExist('tl_theme')) {
+        if (!$schemaManager->tablesExist(['tl_theme'])) {
             return false;
         }
 

--- a/src/Migration/Version200/ContentElementsMigration.php
+++ b/src/Migration/Version200/ContentElementsMigration.php
@@ -30,7 +30,7 @@ class ContentElementsMigration extends AbstractMigration
         $schemaManager = $this->connection->createSchemaManager();
 
         if (
-            !$schemaManager->tablesExist('tl_content')
+            !$schemaManager->tablesExist(['tl_content'])
             || !\array_key_exists('type', $schemaManager->listTableColumns('tl_content'))
         ) {
             return false;

--- a/src/Migration/Version200/LayoutContentMigration.php
+++ b/src/Migration/Version200/LayoutContentMigration.php
@@ -30,7 +30,7 @@ class LayoutContentMigration extends AbstractMigration
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        if (!$schemaManager->tablesExist('tl_theme')) {
+        if (!$schemaManager->tablesExist(['tl_theme'])) {
             return false;
         }
 

--- a/src/Migration/Version220/CustomLayoutSectionMigration.php
+++ b/src/Migration/Version220/CustomLayoutSectionMigration.php
@@ -30,7 +30,7 @@ class CustomLayoutSectionMigration extends AbstractMigration
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        if (!$schemaManager->tablesExist('tl_layout')) {
+        if (!$schemaManager->tablesExist(['tl_layout'])) {
             return false;
         }
 

--- a/src/Migration/Version230/ArticleTemplateMigration.php
+++ b/src/Migration/Version230/ArticleTemplateMigration.php
@@ -29,7 +29,7 @@ class ArticleTemplateMigration extends AbstractMigration
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        if (!$schemaManager->tablesExist('tl_article')) {
+        if (!$schemaManager->tablesExist(['tl_article'])) {
             return false;
         }
 


### PR DESCRIPTION
## Summary
Fixes Doctrine DBAL 4 compatibility in migrations by changing `tablesExist()` calls from string to array syntax.

## Changes
- `tablesExist('tl_theme')` -> `tablesExist(['tl_theme'])`
- `tablesExist('tl_content')` -> `tablesExist(['tl_content'])`
- `tablesExist('tl_layout')` -> `tablesExist(['tl_layout'])`
- `tablesExist('tl_article')` -> `tablesExist(['tl_article'])`

Updated files:
- `src/Migration/Version200/ArticleSpacingMigration.php`
- `src/Migration/Version200/ContentElementsMigration.php`
- `src/Migration/Version200/LayoutContentMigration.php`
- `src/Migration/Version220/CustomLayoutSectionMigration.php`
- `src/Migration/Version230/ArticleTemplateMigration.php`

## Compatibility
This is compatible with both DBAL 3 and DBAL 4.
